### PR TITLE
Convert Oauth2GenericAuthenticator as a plugin

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oauth2/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.oauth2/pom.xml
@@ -53,7 +53,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Private-Package>
                             org.wso2.carbon.identity.application.authenticator.oauth2.internal

--- a/features/org.wso2.carbon.identity.application.authenticator.oauth2.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.application.authenticator.oauth2.server.feature/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.outbound.auth.oauth2</groupId>
+        <artifactId>identity-outbound-oauth-oauth2</artifactId>
+        <version>1.0.5-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.application.authenticator.oauth2.server.feature</artifactId>
+    <packaging>pom</packaging>
+    <name>OAuth2 Related IDP Functions Server Feature</name>
+    <url>http://wso2.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.outbound.auth.oauth2</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authenticator.oauth2</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>carbon-p2-plugin</artifactId>
+                <version>${carbon.p2.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>4-p2-feature-generation</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>p2-feature-gen</goal>
+                        </goals>
+                        <configuration>
+                            <id>org.wso2.carbon.identity.application.authenticator.oauth2.server</id>
+                            <adviceFile>
+                                <properties>
+                                    <propertyDef>org.wso2.carbon.p2.category.type:server</propertyDef>
+                                </properties>
+                            </adviceFile>
+                            <bundles>
+                                <bundleDef>org.wso2.carbon.identity.outbound.auth.oauth2:org.wso2.carbon.identity.application.authenticator.oauth2</bundleDef>
+                            </bundles>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/features/org.wso2.carbon.identity.outbound.auth.oauth2.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.outbound.auth.oauth2.server.feature/pom.xml
@@ -26,9 +26,9 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>org.wso2.carbon.identity.application.authenticator.oauth2.server.feature</artifactId>
+    <artifactId>org.wso2.carbon.identity.outbound.auth.oauth2.server.feature</artifactId>
     <packaging>pom</packaging>
-    <name>OAuth2 Related IDP Functions Server Feature</name>
+    <name>OAuth2 Generic Authenticator Server Feature</name>
     <url>http://wso2.org</url>
 
     <dependencies>
@@ -52,7 +52,7 @@
                             <goal>p2-feature-gen</goal>
                         </goals>
                         <configuration>
-                            <id>org.wso2.carbon.identity.application.authenticator.oauth2.server</id>
+                            <id>org.wso2.carbon.identity.outbound.auth.oauth2.server</id>
                             <adviceFile>
                                 <properties>
                                     <propertyDef>org.wso2.carbon.p2.category.type:server</propertyDef>

--- a/pom.xml
+++ b/pom.xml
@@ -37,20 +37,18 @@
         <tag>HEAD</tag>
     </scm>
 
-    <profiles>
-        <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <modules>
-                <module>components/org.wso2.carbon.identity.application.authenticator.oauth2</module>
-            </modules>
-        </profile>
-    </profiles>
+    <modules>
+        <module>components/org.wso2.carbon.identity.application.authenticator.oauth2</module>
+        <module>features/org.wso2.carbon.identity.application.authenticator.oauth2.server.feature</module>
+    </modules>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.outbound.auth.oauth2</groupId>
+                <artifactId>org.wso2.carbon.identity.application.authenticator.oauth2</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
@@ -234,6 +232,7 @@
         <osgi.framework.version.range>[1.8,2)</osgi.framework.version.range>
         <json.version.range>[3.0,4)</json.version.range>
         <jacoco.version>0.7.9</jacoco.version>
+        <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
 
         <sonar.coverage.exclusions>
             **/*Exception.java,

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <modules>
         <module>components/org.wso2.carbon.identity.application.authenticator.oauth2</module>
-        <module>features/org.wso2.carbon.identity.application.authenticator.oauth2.server.feature</module>
+        <module>features/org.wso2.carbon.identity.outbound.auth.oauth2.server.feature</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
Add [Oauth2GenericAuthenticator](https://github.com/wso2-extensions/identity-outbound-auth-oauth2) as an authenticator inside plugins OOTB with Product IS.

Related issue: https://github.com/wso2/product-is/issues/14166