### PR TITLE
Development

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oauth2/src/main/java/org.wso2.carbon.identity.application.authenticator.oauth2/Oauth2GenericAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oauth2/src/main/java/org.wso2.carbon.identity.application.authenticator.oauth2/Oauth2GenericAuthenticator.java
@@ -81,15 +81,14 @@ public class Oauth2GenericAuthenticator extends AbstractApplicationAuthenticator
         }
 
         try {
-            String stateToken = setStateToken(context);
+
             Map<String, String> authenticatorProperties = getAuthenticatorProperties(context);
             String clientId = getClientId(authenticatorProperties);
             String callbackUrl = getCallbackURL(authenticatorProperties, request.getServerName(),
                     request.getServerPort());
             String authorizationEP = getAuthorizationServerEndpoint(authenticatorProperties);
             String scope = authenticatorProperties.get(Oauth2GenericAuthenticatorConstants.SCOPE);
-            String state = stateToken + "," + Oauth2GenericAuthenticatorConstants.OAUTH2_LOGIN_TYPE;
-            context.setContextIdentifier(stateToken);
+            String state = setState(context);
 
             OAuthClientRequest authorizationRequest = OAuthClientRequest.authorizationLocation(authorizationEP)
                     .setClientId(clientId)
@@ -488,9 +487,10 @@ public class Oauth2GenericAuthenticator extends AbstractApplicationAuthenticator
         }
     }
 
-    protected String setStateToken(AuthenticationContext context) {
+    protected String setState(AuthenticationContext context) {
 
-        String state = context.getContextIdentifier();
+        String stateToken = context.getContextIdentifier();
+        String state = stateToken + "," + Oauth2GenericAuthenticatorConstants.OAUTH2_LOGIN_TYPE;
         return state;
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oauth2/src/main/java/org.wso2.carbon.identity.application.authenticator.oauth2/Oauth2GenericAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oauth2/src/main/java/org.wso2.carbon.identity.application.authenticator.oauth2/Oauth2GenericAuthenticator.java
@@ -79,7 +79,7 @@ public class Oauth2GenericAuthenticator extends AbstractApplicationAuthenticator
         if (logger.isDebugEnabled()) {
             logger.debug("Initiating authentication request");
         }
-        String stateToken = generateState();
+        String stateToken = setState(context);
         try {
             Map<String, String> authenticatorProperties = getAuthenticatorProperties(context);
             String clientId = getClientId(authenticatorProperties);
@@ -487,10 +487,10 @@ public class Oauth2GenericAuthenticator extends AbstractApplicationAuthenticator
         }
     }
 
-    protected String generateState() {
+    protected String setState(AuthenticationContext context) {
 
-        SecureRandom random = new SecureRandom();
-        return new BigInteger(130, random).toString(32);
+        String state = context.getContextIdentifier();
+        return state;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.application.authenticator.oauth2/src/main/java/org.wso2.carbon.identity.application.authenticator.oauth2/Oauth2GenericAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oauth2/src/main/java/org.wso2.carbon.identity.application.authenticator.oauth2/Oauth2GenericAuthenticator.java
@@ -79,8 +79,9 @@ public class Oauth2GenericAuthenticator extends AbstractApplicationAuthenticator
         if (logger.isDebugEnabled()) {
             logger.debug("Initiating authentication request");
         }
-        String stateToken = setState(context);
+
         try {
+            String stateToken = setStateToken(context);
             Map<String, String> authenticatorProperties = getAuthenticatorProperties(context);
             String clientId = getClientId(authenticatorProperties);
             String callbackUrl = getCallbackURL(authenticatorProperties, request.getServerName(),
@@ -487,7 +488,7 @@ public class Oauth2GenericAuthenticator extends AbstractApplicationAuthenticator
         }
     }
 
-    protected String setState(AuthenticationContext context) {
+    protected String setStateToken(AuthenticationContext context) {
 
         String state = context.getContextIdentifier();
         return state;

--- a/components/org.wso2.carbon.identity.application.authenticator.oauth2/src/main/java/org.wso2.carbon.identity.application.authenticator.oauth2/Oauth2GenericAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oauth2/src/main/java/org.wso2.carbon.identity.application.authenticator.oauth2/Oauth2GenericAuthenticatorConstants.java
@@ -24,7 +24,6 @@ public class Oauth2GenericAuthenticatorConstants {
 
     public static final String OAUTH2_GRANT_TYPE_CODE = "code";
     public static final String EMAIL = "email";
-    public static final String DEFAULT_USER_IDENTIFIER = "id";
     public static final String OAUTH2_PARAM_STATE = "state";
     public static final String OAUTH2_LOGIN_TYPE = "oauth2";
     public static final String AUTHENTICATOR_NAME = "OAUTH2";

--- a/components/org.wso2.carbon.identity.application.authenticator.oauth2/src/main/java/org.wso2.carbon.identity.application.authenticator.oauth2/Oauth2GenericAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oauth2/src/main/java/org.wso2.carbon.identity.application.authenticator.oauth2/Oauth2GenericAuthenticatorConstants.java
@@ -24,6 +24,7 @@ public class Oauth2GenericAuthenticatorConstants {
 
     public static final String OAUTH2_GRANT_TYPE_CODE = "code";
     public static final String EMAIL = "email";
+    public static final String DEFAULT_USER_IDENTIFIER = "id";
     public static final String OAUTH2_PARAM_STATE = "state";
     public static final String OAUTH2_LOGIN_TYPE = "oauth2";
     public static final String AUTHENTICATOR_NAME = "OAUTH2";


### PR DESCRIPTION
## Purpose

- Avoid changing the ContextIdentifier.
- set state parameter same as default authenticator [1].
- Fixes: https://github.com/wso2/product-is/issues/15055

[1]. https://github.com/wso2-extensions/identity-outbound-auth-oidc/blob/67047ea4bca14c1c969ff2c69694f8eef3e5c334/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java#L461


