### PR TITLE
Fix session data key cache removal

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oauth2/src/main/java/org.wso2.carbon.identity.application.authenticator.oauth2/Oauth2GenericAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oauth2/src/main/java/org.wso2.carbon.identity.application.authenticator.oauth2/Oauth2GenericAuthenticator.java
@@ -79,7 +79,7 @@ public class Oauth2GenericAuthenticator extends AbstractApplicationAuthenticator
         if (logger.isDebugEnabled()) {
             logger.debug("Initiating authentication request");
         }
-        String stateToken = generateState();
+
         try {
             Map<String, String> authenticatorProperties = getAuthenticatorProperties(context);
             String clientId = getClientId(authenticatorProperties);
@@ -87,8 +87,7 @@ public class Oauth2GenericAuthenticator extends AbstractApplicationAuthenticator
                     request.getServerPort());
             String authorizationEP = getAuthorizationServerEndpoint(authenticatorProperties);
             String scope = authenticatorProperties.get(Oauth2GenericAuthenticatorConstants.SCOPE);
-            String state = stateToken + "," + Oauth2GenericAuthenticatorConstants.OAUTH2_LOGIN_TYPE;
-            context.setContextIdentifier(stateToken);
+            String state = getStateParameter(context);
 
             OAuthClientRequest authorizationRequest = OAuthClientRequest.authorizationLocation(authorizationEP)
                     .setClientId(clientId)
@@ -487,10 +486,9 @@ public class Oauth2GenericAuthenticator extends AbstractApplicationAuthenticator
         }
     }
 
-    protected String generateState() {
+    protected String getStateParameter(AuthenticationContext context) {
 
-        SecureRandom random = new SecureRandom();
-        return new BigInteger(130, random).toString(32);
+        return context.getContextIdentifier() + "," + Oauth2GenericAuthenticatorConstants.OAUTH2_LOGIN_TYPE;
     }
 
     @Override


### PR DESCRIPTION
## Description
After completing the authentication flow, the session data key must be removed from the cache and revoked, and the user must not be able to log in again using that session data key. Setting state from context can solve the issue.

## Related Issue
- https://github.com/wso2/product-is/issues/15055