### PR TITLE
Fix breaking change of generateState()

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oauth2/src/main/java/org.wso2.carbon.identity.application.authenticator.oauth2/Oauth2GenericAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oauth2/src/main/java/org.wso2.carbon.identity.application.authenticator.oauth2/Oauth2GenericAuthenticator.java
@@ -87,7 +87,7 @@ public class Oauth2GenericAuthenticator extends AbstractApplicationAuthenticator
                     request.getServerPort());
             String authorizationEP = getAuthorizationServerEndpoint(authenticatorProperties);
             String scope = authenticatorProperties.get(Oauth2GenericAuthenticatorConstants.SCOPE);
-            String state = getStateParameter(context);
+            String state = generateState(context);
 
             OAuthClientRequest authorizationRequest = OAuthClientRequest.authorizationLocation(authorizationEP)
                     .setClientId(clientId)
@@ -486,7 +486,17 @@ public class Oauth2GenericAuthenticator extends AbstractApplicationAuthenticator
         }
     }
 
-    protected String getStateParameter(AuthenticationContext context) {
+    /**
+     * @deprecated Use {@link #generateState(AuthenticationContext)} instead.
+     */
+    @Deprecated
+    protected String generateState() {
+
+        SecureRandom random = new SecureRandom();
+        return new BigInteger(130, random).toString(32);
+    }
+
+    protected String generateState(AuthenticationContext context) {
 
         return context.getContextIdentifier() + "," + Oauth2GenericAuthenticatorConstants.OAUTH2_LOGIN_TYPE;
     }


### PR DESCRIPTION
## Description
After completing the authentication flow, the session data key must be removed from the cache and revoked, and the user must not be able to log in again using that session data key. Setting state from context can solve the issue.

Deprecation notice added for generateState() and introduced generateState(AuthenticationContext).

## Related PR
- https://github.com/wso2-extensions/identity-outbound-auth-oauth2/pull/19

## Related Issue
- https://github.com/wso2/product-is/issues/15055